### PR TITLE
Remove custom maven repo from Android AppsFlyer.gdap file

### DIFF
--- a/android-plugin/AppsFlyer.gdap
+++ b/android-plugin/AppsFlyer.gdap
@@ -8,4 +8,3 @@ binary="AppsFlyer.release.aar"
 
 local=[]
 remote=["com.appsflyer:af-android-sdk:6.1.+"]
-custom_maven_repos=["https://dl.bintray.com/mobilap/maven/"]


### PR DESCRIPTION
Bintray has been shut down, resulting in a 502 error when attempting to compile the plugin. Removing it allows the plugin to check Maven central instead of bintray, which works fine.